### PR TITLE
fix(ios): prefix native classes with N instead of NS

### DIFF
--- a/packages/label/platforms/ios/src/NLabel.swift
+++ b/packages/label/platforms/ios/src/NLabel.swift
@@ -1,8 +1,8 @@
 import UIKit
 
 @objcMembers
-@objc(NSLabel)
-class NSLabel: UILabel {
+@objc(NLabel)
+class NLabel: UILabel {
   var zoomScale:Float = 1.0;
   var textContainerInset: UIEdgeInsets = UIEdgeInsets.zero
   var padding: UIEdgeInsets = UIEdgeInsets.zero

--- a/packages/label/platforms/ios/src/NLabelTextView.swift
+++ b/packages/label/platforms/ios/src/NLabelTextView.swift
@@ -1,8 +1,12 @@
 import UIKit
 
+// The Obj-C runtime has a flat namespace, so the classes exported from here use
+// an `N` prefix rather than `NS`. This one used to be exported as `NSTextView`,
+// which AppKit owns: on Mac Catalyst the collision dropped the class from the
+// generated NativeScript metadata ("ReferenceError: NSTextView is not defined").
 @objcMembers
-@objc(NSTextView)
-class NSTextView: UITextView {
+@objc(NLabelTextView)
+class NLabelTextView: UITextView {
   var padding: UIEdgeInsets = UIEdgeInsets.zero
   var borderThickness:UIEdgeInsets = UIEdgeInsets.zero
   override init(frame: CGRect, textContainer: NSTextContainer?) {

--- a/packages/label/platforms/ios/src/NLabelUtils.swift
+++ b/packages/label/platforms/ios/src/NLabelUtils.swift
@@ -2,8 +2,8 @@ import Foundation
 import UIKit
 
 @objcMembers
-@objc(NSLabelUtils)
-class NSLabelUtils: NSObject {
+@objc(NLabelUtils)
+class NLabelUtils: NSObject {
   class func setTextDecorationAndTransformOn(view:UIView!, text:String!, textDecoration:String!, letterSpacing:CGFloat, lineHeight:CGFloat, color:UIColor!) {
     let attrDict:NSMutableDictionary! = NSMutableDictionary()
     var paragraphStyle:NSMutableParagraphStyle! = nil
@@ -89,9 +89,9 @@ class NSLabelUtils: NSObject {
   class func inset(rect:CGRect, uIEdgeInsets:UIEdgeInsets) -> CGRect {
     return rect.inset(by: uIEdgeInsets)
   }
-  enum NSLabelOrNSTextView: Equatable {
-      case NSLabel(NSLabel)
-      case NSTextView(NSTextView)
+  enum NLabelOrNLabelTextView: Equatable {
+      case NLabel(NLabel)
+      case NLabelTextView(NLabelTextView)
   }
   enum Component {
     case `switch`(UISwitch)
@@ -110,10 +110,10 @@ class NSLabelUtils: NSObject {
   class func updateFontRatio(_ view: UIView, ratio: CGFloat){
     var currentAttributedString: NSAttributedString? = nil
     switch view {
-    case is NSLabel:
-      currentAttributedString = (view as! NSLabel).attributedText
-    case is NSTextView:
-      currentAttributedString = (view as! NSTextView).attributedText
+    case is NLabel:
+      currentAttributedString = (view as! NLabel).attributedText
+    case is NLabelTextView:
+      currentAttributedString = (view as! NLabelTextView).attributedText
     default: break
     }
     if (currentAttributedString == nil) {
@@ -141,10 +141,10 @@ class NSLabelUtils: NSObject {
     
     if (found) {
       switch view {
-      case is NSLabel:
-        (view as! NSLabel).attributedText = toChange;
-      case is NSTextView:
-        (view as! NSTextView).attributedText = toChange;
+      case is NLabel:
+        (view as! NLabel).attributedText = toChange;
+      case is NLabelTextView:
+        (view as! NLabelTextView).attributedText = toChange;
       default: break
       }
     }

--- a/packages/label/platforms/ios/src/UILabelLinkHandler.swift
+++ b/packages/label/platforms/ios/src/UILabelLinkHandler.swift
@@ -22,7 +22,7 @@ class LabelLinkGestureRecognizer : UITapGestureRecognizer {
 }
   
   @objc func handleTap(tapGesture: UIGestureRecognizer) {
-   guard let label = tapGesture.view  as? NSLabel, let attributedText: NSAttributedString = label.attributedText, tapGesture.state == .ended else {
+   guard let label = tapGesture.view  as? NLabel, let attributedText: NSAttributedString = label.attributedText, tapGesture.state == .ended else {
      return
    }
    let bounds = label.bounds

--- a/src/label/index.ios.ts
+++ b/src/label/index.ios.ts
@@ -28,11 +28,11 @@ export { createNativeAttributedString } from '@nativescript-community/text';
 export * from './index-common';
 
 @NativeClass
-class NSLabelLinkHandlerTapDelegateImpl extends NSObject implements UILabelLinkHandlerTapDelegate {
+class NLabelLinkHandlerTapDelegateImpl extends NSObject implements UILabelLinkHandlerTapDelegate {
     public static ObjCProtocols = [UILabelLinkHandlerTapDelegate];
     private mOwner: WeakRef<Label>;
-    public static initWithOwner(owner: WeakRef<Label>): NSLabelLinkHandlerTapDelegateImpl {
-        const handler = NSLabelLinkHandlerTapDelegateImpl.new() as NSLabelLinkHandlerTapDelegateImpl;
+    public static initWithOwner(owner: WeakRef<Label>): NLabelLinkHandlerTapDelegateImpl {
+        const handler = NLabelLinkHandlerTapDelegateImpl.new() as NLabelLinkHandlerTapDelegateImpl;
         handler.mOwner = owner;
         return handler;
     }
@@ -127,14 +127,14 @@ class LabelNSTextViewDelegateImpl extends NSObject implements UITextViewDelegate
         return impl;
     }
 
-    textViewShouldInteractWithURLInRangeInteraction?(textView: NSTextView, URL: NSURL, characterRange: NSRange, interaction: UITextItemInteraction) {
+    textViewShouldInteractWithURLInRangeInteraction?(textView: NLabelTextView, URL: NSURL, characterRange: NSRange, interaction: UITextItemInteraction) {
         const owner = this._owner.get();
         if (owner) {
             return owner.textViewShouldInteractWithURLInRangeInteraction(textView, URL, characterRange, interaction);
         }
         return false;
     }
-    textViewDidChange?(textView: NSTextView) {
+    textViewDidChange?(textView: NLabelTextView) {
         const owner = this._owner.get();
         if (owner) {
             owner.textViewDidChange(textView);
@@ -145,7 +145,7 @@ class LabelNSTextViewDelegateImpl extends NSObject implements UITextViewDelegate
 @NativeClass
 class LabelObserverClass extends NSObject {
     _owner: WeakRef<Label>;
-    observeValueForKeyPathOfObjectChangeContext(path: string, tv: NSTextView | NSLabel) {
+    observeValueForKeyPathOfObjectChangeContext(path: string, tv: NLabelTextView | NLabel) {
         const owner = this._owner?.get();
         if (owner) {
             owner.updateVerticalAlignment();
@@ -158,8 +158,8 @@ export class Label extends LabelBase {
     [key: symbol]: (...args: any[]) => any | void;
 
     private mObserver: LabelObserverClass;
-    nativeViewProtected: NSLabel | NSTextView;
-    nativeTextViewProtected: NSLabel | NSTextView;
+    nativeViewProtected: NLabel | NLabelTextView;
+    nativeTextViewProtected: NLabel | NLabelTextView;
     attributedString: NSAttributedString;
     private mDelegate: LabelNSTextViewDelegateImpl;
     private mFixedSize: FixedSize;
@@ -177,9 +177,9 @@ export class Label extends LabelBase {
     public createNativeView() {
         if (this.selectable) {
             this.isUsingNSTextView = true;
-            return NSTextView.new();
+            return NLabelTextView.new();
         }
-        return NSLabel.new();
+        return NLabel.new();
     }
 
     @profile
@@ -190,7 +190,7 @@ export class Label extends LabelBase {
             this.mObserver = LabelObserverClass.alloc().init() as LabelObserverClass;
             this.mObserver._owner = new WeakRef(this);
             this.mDelegate = LabelNSTextViewDelegateImpl.initWithOwner(new WeakRef(this));
-            (nativeView as NSTextView).delegate = this.mDelegate;
+            (nativeView as NLabelTextView).delegate = this.mDelegate;
             nativeView.addObserverForKeyPathOptionsContext(this.mObserver, 'contentSize', NSKeyValueObservingOptions.New, null);
         }
     }
@@ -198,7 +198,7 @@ export class Label extends LabelBase {
         this.mDelegate = null;
         const nativeView = this.nativeTextViewProtected;
         if (this.isUsingNSTextView) {
-            (nativeView as NSTextView).delegate = null;
+            (nativeView as NLabelTextView).delegate = null;
         }
         if (this.mTapGestureRecognizer) {
             this.nativeViewProtected.removeGestureRecognizer(this.mTapGestureRecognizer);
@@ -236,7 +236,7 @@ export class Label extends LabelBase {
             this.updateVerticalAlignment();
         }
     }
-    computeTextHeight(tv: NSTextView | NSLabel, size: CGSize) {
+    computeTextHeight(tv: NLabelTextView | NLabel, size: CGSize) {
         const oldtextContainerInset = tv.textContainerInset;
         tv.textContainerInset = UIEdgeInsetsZero;
         // if (tv.attributedText) {
@@ -268,12 +268,12 @@ export class Label extends LabelBase {
         const result = this.updateTextContainerInset(nativeView, applyVerticalTextAlignment);
         nativeView.textContainerInset = result;
         if (this.isUsingNSTextView) {
-            (nativeView as NSTextView).contentInset = UIEdgeInsetsZero;
+            (nativeView as NLabelTextView).contentInset = UIEdgeInsetsZero;
         }
         // this.requestLayout();
     }
 
-    updateTextContainerInset(tv: NSTextView | NSLabel, applyVerticalTextAlignment = true) {
+    updateTextContainerInset(tv: NLabelTextView | NLabel, applyVerticalTextAlignment = true) {
         let inset;
         const top = Utils.layout.toDeviceIndependentPixels(this.effectivePaddingTop + this.effectiveBorderTopWidth);
         const right = Utils.layout.toDeviceIndependentPixels(this.effectivePaddingRight + this.effectiveBorderRightWidth);
@@ -363,7 +363,7 @@ export class Label extends LabelBase {
     }
 
     private _measureNativeView(width: number, widthMode: number, height: number, heightMode: number): { width: number; height: number } {
-        const view = this.nativeTextViewProtected as NSLabel;
+        const view = this.nativeTextViewProtected as NLabel;
 
         const nativeSize = view.textRectForBoundsLimitedToNumberOfLines(
             CGRectMake(
@@ -449,7 +449,7 @@ export class Label extends LabelBase {
     // }
     _tappable;
     mTapGestureRecognizer: LabelLinkGestureRecognizer;
-    mTapDelegate: NSLabelLinkHandlerTapDelegateImpl;
+    mTapDelegate: NLabelLinkHandlerTapDelegateImpl;
     _setTappableState(tappable) {
         if (this._tappable !== tappable) {
             this._tappable = tappable;
@@ -458,7 +458,7 @@ export class Label extends LabelBase {
                 // so we override
             } else {
                 if (this._tappable && !this.mTapGestureRecognizer) {
-                    this.mTapDelegate = NSLabelLinkHandlerTapDelegateImpl.initWithOwner(new WeakRef(this));
+                    this.mTapDelegate = NLabelLinkHandlerTapDelegateImpl.initWithOwner(new WeakRef(this));
                     // associate handler with menuItem or it will get collected by JSC.
                     this.mTapGestureRecognizer = LabelLinkGestureRecognizer.alloc().initWithDelegate(this.mTapDelegate);
                     this.nativeViewProtected.addGestureRecognizer(this.mTapGestureRecognizer);
@@ -470,7 +470,7 @@ export class Label extends LabelBase {
         // this.updateInteractionState();
     }
 
-    textViewShouldInteractWithURLInRangeInteraction?(textView: NSTextView, url: NSURL, characterRange: NSRange, interaction: UITextItemInteraction) {
+    textViewShouldInteractWithURLInRangeInteraction?(textView: NLabelTextView, url: NSURL, characterRange: NSRange, interaction: UITextItemInteraction) {
         if (!this.formattedText?.spans) {
             if (url) {
                 this.notify({ eventName: Span.linkTapEvent, link: url?.toString() });
@@ -503,7 +503,7 @@ export class Label extends LabelBase {
         const nativeView = this.nativeTextViewProtected;
         if (!this.html) {
             if (this.isUsingNSTextView) {
-                (nativeView as NSTextView).selectable = this.selectable === true;
+                (nativeView as NLabelTextView).selectable = this.selectable === true;
             }
             this.attributedString = null;
         } else if (this.html instanceof NSAttributedString) {
@@ -518,7 +518,7 @@ export class Label extends LabelBase {
             const familyName = style.fontFamily || (style.fontInternal && style.fontInternal.fontFamily) || undefined;
 
             // we need to pass color because initWithDataOptionsDocumentAttributesError
-            // will set a default color preventing the NSTextView from applying its color
+            // will set a default color preventing the NLabelTextView from applying its color
 
             const color = this.color ? (this.color instanceof Color ? this.color : new Color(this.color)) : undefined;
             const params = {
@@ -535,7 +535,7 @@ export class Label extends LabelBase {
                 const linkColor = this.linkColor ? (this.linkColor instanceof Color ? this.linkColor : new Color(this.linkColor)) : undefined;
                 Object.assign(params, {
                     useCustomLinkTag: true,
-                    lineBreak: (nativeView as NSLabel).lineBreakMode,
+                    lineBreak: (nativeView as NLabel).lineBreakMode,
                     linkDecoration: this.linkUnderline ? 'underline' : undefined,
                     linkColor
                 });
@@ -548,7 +548,7 @@ export class Label extends LabelBase {
             this._setTappableState(hasLink);
             // this.updateInteractionState(hasLink);
             if (this.isUsingNSTextView) {
-                (nativeView as NSTextView).selectable = this.selectable === true || hasLink;
+                (nativeView as NLabelTextView).selectable = this.selectable === true || hasLink;
             }
             this.attributedString = result;
         }
@@ -581,7 +581,7 @@ export class Label extends LabelBase {
         if (this.isUsingNSTextView) {
             const color = !this.linkColor || this.linkColor instanceof Color ? this.linkColor : new Color(this.linkColor);
             const nativeView = this.nativeTextViewProtected;
-            let attributes = this.isUsingNSTextView ? (nativeView as NSTextView).linkTextAttributes : null;
+            let attributes = this.isUsingNSTextView ? (nativeView as NLabelTextView).linkTextAttributes : null;
             if (!(attributes instanceof NSMutableDictionary)) {
                 this.defaultLinkTextAttributes = attributes;
                 attributes = NSMutableDictionary.new();
@@ -605,7 +605,7 @@ export class Label extends LabelBase {
                     attributes.setValueForKey(UIColor.clearColor, NSUnderlineColorAttributeName);
                 }
             }
-            (nativeView as NSTextView).linkTextAttributes = attributes;
+            (nativeView as NLabelTextView).linkTextAttributes = attributes;
             // } else {
             // this._setNativeText();
         }
@@ -617,7 +617,7 @@ export class Label extends LabelBase {
     [selectableProperty.setNative](value: boolean) {
         const nativeView = this.nativeTextViewProtected;
         if (this.isUsingNSTextView) {
-            (nativeView as NSTextView).selectable = value;
+            (nativeView as NLabelTextView).selectable = value;
         }
         // this.updateInteractionState();
     }
@@ -721,7 +721,7 @@ export class Label extends LabelBase {
         nativeView.attributedText = attrText;
     }
     updateTextViewContentInset(data: Partial<UIEdgeInsets>) {
-        // const nativeView = this.nativeTextViewProtected as NSTextView;
+        // const nativeView = this.nativeTextViewProtected as NLabelTextView;
         // const contentInset = nativeView.contentInset;
         // nativeView.contentInset = Object.assign(
         //     {
@@ -777,9 +777,9 @@ export class Label extends LabelBase {
         const numberLines = !value || value === 'none' ? 0 : typeof value === 'string' ? parseInt(value, 10) : value;
         const nativeView = this.nativeTextViewProtected;
         if (this.isUsingNSTextView) {
-            (nativeView as NSTextView).textContainer.maximumNumberOfLines = numberLines;
+            (nativeView as NLabelTextView).textContainer.maximumNumberOfLines = numberLines;
         } else {
-            (nativeView as NSLabel).numberOfLines = numberLines;
+            (nativeView as NLabel).numberOfLines = numberLines;
         }
     }
 
@@ -787,9 +787,9 @@ export class Label extends LabelBase {
     [lineBreakProperty.setNative](value: string) {
         const nativeView = this.nativeTextViewProtected;
         if (this.isUsingNSTextView) {
-            (nativeView as NSTextView).textContainer.lineBreakMode = lineBreakToLineBreakMode(value);
+            (nativeView as NLabelTextView).textContainer.lineBreakMode = lineBreakToLineBreakMode(value);
         } else {
-            (nativeView as NSLabel).lineBreakMode = lineBreakToLineBreakMode(value);
+            (nativeView as NLabel).lineBreakMode = lineBreakToLineBreakMode(value);
         }
     }
 
@@ -807,27 +807,27 @@ export class Label extends LabelBase {
     [whiteSpaceProperty.setNative](value: CoreTypes.WhiteSpaceType) {
         const nativeView = this.nativeTextViewProtected;
         if (this.isUsingNSTextView) {
-            (nativeView as NSTextView).textContainer.lineBreakMode = whiteSpaceToLineBreakMode(value);
+            (nativeView as NLabelTextView).textContainer.lineBreakMode = whiteSpaceToLineBreakMode(value);
             if (!this.maxLines) {
                 if (value === 'normal') {
-                    (nativeView as NSTextView).textContainer.maximumNumberOfLines = 0;
+                    (nativeView as NLabelTextView).textContainer.maximumNumberOfLines = 0;
                 } else {
-                    (nativeView as NSTextView).textContainer.maximumNumberOfLines = 1;
+                    (nativeView as NLabelTextView).textContainer.maximumNumberOfLines = 1;
                 }
             }
         } else {
-            (nativeView as NSLabel).lineBreakMode = whiteSpaceToLineBreakMode(value);
+            (nativeView as NLabel).lineBreakMode = whiteSpaceToLineBreakMode(value);
             if (!this.maxLines) {
                 if (value === 'normal') {
-                    (nativeView as NSLabel).numberOfLines = 0;
+                    (nativeView as NLabel).numberOfLines = 0;
                 } else {
-                    (nativeView as NSLabel).numberOfLines = 1;
+                    (nativeView as NLabel).numberOfLines = 1;
                 }
             }
         }
     }
 
-    updateAutoFontSize({ force = false, height, onlyMeasure = false, textView, width }: { textView: NSTextView | NSLabel; width?; height?; force?: boolean; onlyMeasure?: boolean }) {
+    updateAutoFontSize({ force = false, height, onlyMeasure = false, textView, width }: { textView: NLabelTextView | NLabel; width?; height?; force?: boolean; onlyMeasure?: boolean }) {
         if (!this.mCanUpdateAutoFontSize) {
             this.mNeedAutoFontSizeComputation = true;
         }
@@ -836,7 +836,7 @@ export class Label extends LabelBase {
             if ((!textView.attributedText && !textView.text) || (width === undefined && height === undefined && CGSizeEqualToSize(textView.bounds.size, CGSizeZero))) {
                 return currentFont;
             }
-            const textViewSize = NSLabelUtils.insetWithRectUIEdgeInsets(textView.bounds, textView.padding).size;
+            const textViewSize = NLabelUtils.insetWithRectUIEdgeInsets(textView.bounds, textView.padding).size;
             const fixedWidth = Math.ceil(width !== undefined ? width : textViewSize.width);
             const fixedHeight = Math.ceil(height !== undefined ? height : textViewSize.height);
             if (fixedWidth === 0 || fixedHeight === 0) {
@@ -852,7 +852,7 @@ export class Label extends LabelBase {
             }
             currentFont = textView.font;
             this.mLastAutoSizeKey = autoSizeKey;
-            const nbLines = textView instanceof NSTextView ? textView.textContainer?.maximumNumberOfLines : textView.numberOfLines;
+            const nbLines = textView instanceof NLabelTextView ? textView.textContainer?.maximumNumberOfLines : textView.numberOfLines;
             // we need to reset verticalTextAlignment or computation will be wrong
             this.updateVerticalAlignment(false);
 
@@ -862,7 +862,7 @@ export class Label extends LabelBase {
             const changeFont = !this.useNSAttributedString();
             const updateFontSize = (font) => {
                 if (!changeFont) {
-                    NSLabelUtils.updateFontRatioRatio(textView, font.pointSize / fontSize);
+                    NLabelUtils.updateFontRatioRatio(textView, font.pointSize / fontSize);
                 } else {
                     textView.font = font;
                 }
@@ -917,7 +917,7 @@ export class Label extends LabelBase {
         }
         return currentFont;
     }
-    textViewDidChange(textView: NSTextView) {
+    textViewDidChange(textView: NLabelTextView) {
         //only called when user triggers the text change, not programmatically
         this.updateAutoFontSize({ textView, force: true });
     }

--- a/src/label/typings/ios.d.ts
+++ b/src/label/typings/ios.d.ts
@@ -14,25 +14,25 @@ declare class LabelLinkGestureRecognizer extends UITapGestureRecognizer {
     initWithDelegate(withDelegate: UILabelLinkHandlerTapDelegate): this;
 }
 
-declare class NSLabel extends UILabel {
-    static alloc(): NSLabel; // inherited from NSObject
+declare class NLabel extends UILabel {
+    static alloc(): NLabel; // inherited from NSObject
 
-    static appearance(): NSLabel; // inherited from UIAppearance
+    static appearance(): NLabel; // inherited from UIAppearance
 
-    static appearanceForTraitCollection(trait: UITraitCollection): NSLabel; // inherited from UIAppearance
+    static appearanceForTraitCollection(trait: UITraitCollection): NLabel; // inherited from UIAppearance
 
-    static appearanceForTraitCollectionWhenContainedIn(trait: UITraitCollection, ContainerClass: typeof NSObject): NSLabel; // inherited from UIAppearance
+    static appearanceForTraitCollectionWhenContainedIn(trait: UITraitCollection, ContainerClass: typeof NSObject): NLabel; // inherited from UIAppearance
 
     static appearanceForTraitCollectionWhenContainedInInstancesOfClasses(
         trait: UITraitCollection,
         containerTypes: NSArray<typeof NSObject> | (typeof NSObject)[]
-    ): NSLabel; // inherited from UIAppearance
+    ): NLabel; // inherited from UIAppearance
 
-    static appearanceWhenContainedIn(ContainerClass: typeof NSObject): NSLabel; // inherited from UIAppearance
+    static appearanceWhenContainedIn(ContainerClass: typeof NSObject): NLabel; // inherited from UIAppearance
 
-    static appearanceWhenContainedInInstancesOfClasses(containerTypes: NSArray<typeof NSObject> | (typeof NSObject)[]): NSLabel; // inherited from UIAppearance
+    static appearanceWhenContainedInInstancesOfClasses(containerTypes: NSArray<typeof NSObject> | (typeof NSObject)[]): NLabel; // inherited from UIAppearance
 
-    static new(): NSLabel; // inherited from NSObject
+    static new(): NLabel; // inherited from NSObject
 
     borderThickness: UIEdgeInsets;
 
@@ -45,12 +45,12 @@ declare class NSLabel extends UILabel {
     commonInit(): void;
 }
 
-declare class NSLabelUtils extends NSObject {
-    static alloc(): NSLabelUtils; // inherited from NSObject
+declare class NLabelUtils extends NSObject {
+    static alloc(): NLabelUtils; // inherited from NSObject
 
     static insetWithRectUIEdgeInsets(rect: CGRect, uIEdgeInsets: UIEdgeInsets): CGRect;
 
-    static new(): NSLabelUtils; // inherited from NSObject
+    static new(): NLabelUtils; // inherited from NSObject
 
     static setTextDecorationAndTransformOnViewTextTextDecorationLetterSpacingLineHeightColor(
         view: UIView,
@@ -63,29 +63,29 @@ declare class NSLabelUtils extends NSObject {
     static updateFontRatioRatio(view: UIView, ratio: number): void;
 }
 
-declare class NSTextView extends UITextView {
-    static alloc(): NSTextView; // inherited from NSObject
+declare class NLabelTextView extends UITextView {
+    static alloc(): NLabelTextView; // inherited from NSObject
 
-    static appearance(): NSTextView; // inherited from UIAppearance
+    static appearance(): NLabelTextView; // inherited from UIAppearance
 
-    static appearanceForTraitCollection(trait: UITraitCollection): NSTextView; // inherited from UIAppearance
+    static appearanceForTraitCollection(trait: UITraitCollection): NLabelTextView; // inherited from UIAppearance
 
-    static appearanceForTraitCollectionWhenContainedIn(trait: UITraitCollection, ContainerClass: typeof NSObject): NSTextView; // inherited from UIAppearance
+    static appearanceForTraitCollectionWhenContainedIn(trait: UITraitCollection, ContainerClass: typeof NSObject): NLabelTextView; // inherited from UIAppearance
 
     static appearanceForTraitCollectionWhenContainedInInstancesOfClasses(
         trait: UITraitCollection,
         containerTypes: NSArray<typeof NSObject> | (typeof NSObject)[]
-    ): NSTextView; // inherited from UIAppearance
+    ): NLabelTextView; // inherited from UIAppearance
 
-    static appearanceWhenContainedIn(ContainerClass: typeof NSObject): NSTextView; // inherited from UIAppearance
+    static appearanceWhenContainedIn(ContainerClass: typeof NSObject): NLabelTextView; // inherited from UIAppearance
 
     static appearanceWhenContainedInInstancesOfClasses(
         containerTypes: NSArray<typeof NSObject> | (typeof NSObject)[]
-    ): NSTextView; // inherited from UIAppearance
+    ): NLabelTextView; // inherited from UIAppearance
 
-    static new(): NSTextView; // inherited from NSObject
+    static new(): NLabelTextView; // inherited from NSObject
 
-    static textViewUsingTextLayoutManager(usingTextLayoutManager: boolean): NSTextView; // inherited from UITextView
+    static textViewUsingTextLayoutManager(usingTextLayoutManager: boolean): NLabelTextView; // inherited from UITextView
 
     borderThickness: UIEdgeInsets;
 


### PR DESCRIPTION
## Summary

- The Obj-C runtime has a flat namespace, and `NSTextView` — the class this plugin exports for selectable labels — collides with AppKit's. On Mac Catalyst the collision drops the plugin's class from the generated NativeScript metadata, so any selectable `Label` crashes the app with `ReferenceError: NSTextView is not defined`.
- Rename the three classes exported from the iOS sources so the prefix cannot clash with Apple's again: `NSLabel` → `NLabel`, `NSTextView` → `NLabelTextView`, `NSLabelUtils` → `NLabelUtils`.
- iOS only. Android keeps `com.nativescript.label.NSLabel`: Java packages already namespace it, and renaming would mean rebuilding the prebuilt `.aar`.

## Testing

Built and ran a real app (OSS Weather) as a Mac Catalyst app on Apple Silicon, plus an iOS build to check for regressions.

Symbols present in the generated Mac Catalyst metadata:

| symbol | before | after |
|---|---|---|
| `NLabel` | — | 1 |
| `NLabelTextView` | — | 1 |
| `NLabelUtils` | — | 1 |
| `NSTextView` | 0 (dropped by the collision) | 0 (correctly AppKit's) |

The app previously failed to open any screen using a selectable label; it now launches and renders clean, with no `ReferenceError` in the log.

## Breaking changes

The Obj-C class names change, so anything referencing `NSLabel`, `NSTextView` or `NSLabelUtils` from JS/TS on iOS must use the `N`-prefixed names. `isUsingNSTextView` and `LabelNSTextViewDelegateImpl` deliberately keep their names, so the `Label` JS API itself is unchanged.