### PR TITLE
fix(ios): incorrect sizing resulting in missed link taps

### DIFF
--- a/packages/label/platforms/ios/src/UILabelLinkHandler.swift
+++ b/packages/label/platforms/ios/src/UILabelLinkHandler.swift
@@ -50,7 +50,7 @@ class LabelLinkGestureRecognizer : UITapGestureRecognizer {
      label.padding.right -
      label.borderThickness.left -
      label.borderThickness.right,
-     labelSize.width -
+     labelSize.height -
      label.padding.top -
      label.padding.bottom -
      label.borderThickness.top -


### PR DESCRIPTION
Seems like there is a typo in the measurements that results in un-tappable links in certain conditions. In my case, it was inside a flexbox layout where the text is long enough to wrap. At a certain height the link stopped being tappable. This seems to fix the issue for me. 